### PR TITLE
Added block.py via upload to extend the LUKS loop and pull clevis and crypttab data.

### DIFF
--- a/block.py
+++ b/block.py
@@ -1,0 +1,71 @@
+# This file is part of the sos project: https://github.com/sosreport/sos
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# version 2 of the GNU General Public License.
+#
+# See the LICENSE file in the source distribution for further information.
+
+from sos.report.plugins import Plugin, IndependentPlugin
+
+
+class Block(Plugin, IndependentPlugin):
+
+    short_desc = 'Block device information'
+
+    plugin_name = 'block'
+    profiles = ('storage', 'hardware')
+    verify_packages = ('util-linux',)
+    files = ('/sys/block',)
+
+    def setup(self):
+        self.add_forbidden_path("/sys/block/*/queue/iosched")
+
+        self.add_file_tags({
+            '/sys/block/.*/queue/scheduler': 'scheduler'
+        })
+
+        self.add_cmd_output([
+            "lsblk",
+            "lsblk -t",
+            "lsblk -D",
+            "blkid -c /dev/null",
+            "blockdev --report",
+            "ls -lanR /dev",
+            "ls -lanR /sys/block",
+            "lsblk -O -P",
+            "losetup -a",
+        ])
+
+        # legacy location for non-/run distributions
+        self.add_copy_spec([
+            "/etc/blkid.tab",
+            "/run/blkid/blkid.tab",
+            "/proc/partitions",
+            "/proc/diskstats",
+            "/sys/block/*/queue/",
+            "/sys/block/sd*/device/timeout",
+            "/sys/block/hd*/device/timeout",
+            "/sys/block/sd*/device/state",
+            "/sys/block/loop*/loop/",
+        ])
+
+        cmds = [
+            "parted -s %(dev)s unit s print",
+            "fdisk -l %(dev)s",
+            "udevadm info %(dev)s",
+            "udevadm info -a %(dev)s"
+        ]
+        self.add_blockdev_cmd(cmds, blacklist='ram.*')
+
+        lsblk = self.collect_cmd_output("lsblk -f -a -l")
+        # for LUKS devices, collect cryptsetup luksDump, clevis policy(s), and /etc/crypttab file. 
+        if lsblk['status'] == 0:
+            for line in lsblk['output'].splitlines():
+                if 'crypto_LUKS' in line:
+                    dev = line.split()[0]
+                    self.add_cmd_output('cryptsetup luksDump /dev/%s' % dev)
+                    self.add_cmd_output('clevis luks list -d /dev/%s' % dev)
+                    self.add_copy_spec('/etc/crypttab')
+
+# vim: set et ts=4 sw=4 :


### PR DESCRIPTION
Added two commands to block.py LUKS loop to grab "clevis luks list <dev>" and grab a copy of the /etc/crypttab file

---
Please place an 'X' inside each '[]' to confirm you adhere to our [Contributor Guidelines](https://github.com/sosreport/sos/wiki/Contribution-Guidelines)

- [ ] Is the commit message split over multiple lines and hard-wrapped at 72 characters?
- [ ] Is the subject and message clear and concise?
- [ ] Does the subject start with **[plugin_name]** if submitting a plugin patch or a **[section_name]** if part of the core sosreport code?
- [ ] Does the commit contain a **Signed-off-by: First Lastname <email@example.com>**?
- [ ] Are any related Issues or existing PRs [properly referenced](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) via a Closes (Issue) or Resolved (PR) line?